### PR TITLE
Switch to Facebook's esprima fork

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-var esprima = require('esprima');
+var esprima = require('esprima-fb');
 var recast = require('recast');
 var through = require('through');
 var b = recast.types.builders;
@@ -7,12 +7,12 @@ var n = recast.types.namedTypes;
 var ES6ComputedPropertyKeys = recast.Visitor.extend({
   visitObjectExpression: function(expr) {
     var propertiesWithComputedKeys = expr.properties.filter(function(property) {
-      return property.computedKey;
+      return property.computed;
     });
 
     if (propertiesWithComputedKeys.length > 0) {
       var otherProperties = expr.properties.filter(function(property) {
-        return !property.computedKey;
+        return !property.computed;
       });
 
       var body = [];

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "through": "^2.3",
+    "esprima-fb": "^6001.1001.0-dev-harmony-fb",
     "recast": "^0.5",
-    "esprima": "git+https://github.com/vslinko-forks/esprima.git#6be298aca5f97c55c3fe3f273edb8c6235199d8e"
+    "through": "^2.3"
   },
   "devDependencies": {
     "mocha": "^1.19",


### PR DESCRIPTION
Facebook's esprima fork is maintained at a higher frequency and already
has computed keys implemented which eliminates the need for a custom
fork.

This also makes it easier to integrate with tool chains such as esnext
(which may switch to esprima-fb very soon for similar reasons cc @eventualbuddha).
