### PR TITLE
Add a failing test illustrating the danger of hardcoding `obj`.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -41,4 +41,17 @@ describe('ES6ComputedPropertyKeys', function() {
     expect(z.bar).to.eql(2);
     expect(z[2]).to.eql(3);
   });
+
+  it('should allow referencing an object called "obj" inside a computed property key', function() {
+    var code = [
+      'var obj = {a: "b"};',
+      'var z = {',
+      '  [obj.a]: 2',
+      '};'
+    ].join('\n');
+
+    var z;
+    eval(transform(code));
+    expect(z.b).to.eql(2);
+  });
 });


### PR DESCRIPTION
We must use a unique name for the IFFE variable declaration. This is what es6-computed-properties does, and uses ast-util to do it. I suggest we do something similar here.

@steckel, this is the issue I mentioned if you want to try to fix this.
